### PR TITLE
Improve `init.sh` robustness

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euxo pipefail
+
 chain=$1
 url=$2
 tests=$3

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euxo pipefail
+set -eux
 
 chain=$1
 url=$2


### PR DESCRIPTION
I find `set`ting these very helpful for making shell scripts more robust. It prevents issues and helps debugging and it's considered a shell best-practice.

- `set -e`: Exit immediately on child failures
- `set -u`: Forbid referencing undefined variables
- `set -x`: Print commands being executed
- `set -o pipefail`: Bubble up failures from piped commands