### PR TITLE
Update eth-rpc-tests

### DIFF
--- a/eth-rpc/.solhint.json
+++ b/eth-rpc/.solhint.json
@@ -1,6 +1,8 @@
 {
     "extends": "solhint:recommended",
     "rules": {
+        "no-global-import": "off",
+        "func-visibility": "off",
         "compiler-version": ["error", "^0.8.0"],
         "gas-custom-errors": "off",
         "one-contract-per-file": "off",

--- a/eth-rpc/contracts/Flipper.sol
+++ b/eth-rpc/contracts/Flipper.sol
@@ -20,7 +20,7 @@ contract FlipperCaller {
     address public flipperAddress;
 
     // Constructor to initialize Flipper's address
-    constructor(address _flipperAddress) public {
+    constructor(address _flipperAddress) {
         flipperAddress = _flipperAddress;
     }
 

--- a/eth-rpc/contracts/PiggyBank.sol
+++ b/eth-rpc/contracts/PiggyBank.sol
@@ -6,7 +6,7 @@ contract PiggyBank {
     uint256 private balance;
     address public owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
         balance = 0;
     }

--- a/eth-rpc/contracts/Redstone.sol
+++ b/eth-rpc/contracts/Redstone.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@redstone-finance/evm-connector/contracts/data-services/RapidDemoConsumerBase.sol";
+
+contract ExampleRedstoneShowroom is RapidDemoConsumerBase {
+  function getPrices() public view returns(uint256[] memory) {
+    bytes32[] memory dataFeedIds = new bytes32[](6);
+    dataFeedIds[0] = bytes32("BTC");
+    dataFeedIds[1] = bytes32("ETH");
+    dataFeedIds[2] = bytes32("BNB");
+    dataFeedIds[3] = bytes32("AR");
+    dataFeedIds[4] = bytes32("AVAX");
+    dataFeedIds[5] = bytes32("CELO");
+    return getOracleNumericValuesFromTxMsg(dataFeedIds);
+  }
+}

--- a/eth-rpc/contracts/Tracing.sol
+++ b/eth-rpc/contracts/Tracing.sol
@@ -5,7 +5,7 @@ contract TracingCaller {
 	event TraceEvent(uint256 value, string message);
     address payable public callee;
 
-	constructor(address payable _callee) public payable {
+	constructor(address payable _callee) payable {
         require(_callee != address(0), "Callee address cannot be zero");
         callee = _callee;
     }

--- a/eth-rpc/package-lock.json
+++ b/eth-rpc/package-lock.json
@@ -8,7 +8,7 @@
             "name": "demo",
             "version": "0.0.0",
             "dependencies": {
-                "@parity/revive": "^0.0.12",
+                "@parity/revive": "^0.0.14",
                 "@redstone-finance/evm-connector": "^0.6.2",
                 "ethers": "^5.6.9",
                 "prettier": "^3.5.1",
@@ -1260,9 +1260,9 @@
             "license": "MIT"
         },
         "node_modules/@parity/revive": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/@parity/revive/-/revive-0.0.12.tgz",
-            "integrity": "sha512-pI+T1sn3Z368fWEvepHd4yjnowaPfiZBnVL9wDrJS1uytBAAuwWyPL4HYs/LyCZ2MbRYXMJbtA+5Ls5j7JJBmg==",
+            "version": "0.0.14",
+            "resolved": "https://registry.npmjs.org/@parity/revive/-/revive-0.0.14.tgz",
+            "integrity": "sha512-eEIzBNcrTrgB/44zPBvhtGuMvggp1ieF1ie78xVY1l++ybo9iOTDQtddryk6b5vdx1/sMfhVI7ad6Tyl3ksHug==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "^22.9.0",

--- a/eth-rpc/package-lock.json
+++ b/eth-rpc/package-lock.json
@@ -18,7 +18,6 @@
                 "vitest": "^3.0.6"
             },
             "devDependencies": {
-                "@vitest/ui": "^3.0.6",
                 "typescript": "^5.7.2"
             }
         },
@@ -1310,8 +1309,9 @@
             "version": "1.0.0-next.28",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
             "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@redstone-finance/evm-connector": {
             "version": "0.6.2",
@@ -1869,8 +1869,9 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.6.tgz",
             "integrity": "sha512-N4M2IUG2Q5LCeX4OWs48pQF4P3qsFejmDTc6QWGRFTLPrEe5EvM5HN0WSUnGAmuzQpSWv7ItfSsIJIWaEM2wpQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.0.6",
                 "fflate": "^0.8.2",
@@ -2603,8 +2604,9 @@
             "version": "6.4.3",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
             "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -2618,15 +2620,17 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
             "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-            "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/flatted": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-            "devOptional": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true,
+            "peer": true
         },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
@@ -3219,8 +3223,9 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
             "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -3399,8 +3404,9 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3640,8 +3646,9 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
             "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@polka/url": "^1.0.0-next.24",
                 "mrmime": "^2.0.0",
@@ -3883,8 +3890,9 @@
             "version": "0.2.12",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
             "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fdir": "^6.4.3",
                 "picomatch": "^4.0.2"
@@ -3939,8 +3947,9 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
             "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-            "devOptional": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }

--- a/eth-rpc/package-lock.json
+++ b/eth-rpc/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.0.0",
             "dependencies": {
                 "@parity/revive": "^0.0.12",
-                "ethers": "^6.13.5",
+                "@redstone-finance/evm-connector": "^0.6.2",
+                "ethers": "^5.6.9",
                 "prettier": "^3.5.1",
                 "solc": "^0.8.28",
                 "solhint": "^5.0.5",
@@ -17,11 +18,14 @@
                 "vitest": "^3.0.6"
             },
             "devDependencies": {
+                "@vitest/ui": "^3.0.6",
                 "typescript": "^5.7.2"
             }
         },
         "node_modules/@adraffy/ens-normalize": {
-            "version": "1.10.1",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+            "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
             "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
@@ -47,10 +51,28 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@chainlink/contracts": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.6.1.tgz",
+            "integrity": "sha512-EuwijGexttw0UjfrW+HygwhQIrGAbqpf1ue28R55HhWMHBzphEH0PhWm8DQmFfj5OZNy8Io66N4L0nStkZ3QKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@eth-optimism/contracts": "^0.5.21",
+                "@openzeppelin/contracts": "~4.3.3",
+                "@openzeppelin/contracts-upgradeable": "^4.7.3",
+                "@openzeppelin/contracts-v0.7": "npm:@openzeppelin/contracts@v3.4.2"
+            }
+        },
+        "node_modules/@chainlink/contracts/node_modules/@openzeppelin/contracts": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.3.tgz",
+            "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==",
+            "license": "MIT"
+        },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-            "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+            "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -64,9 +86,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-            "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+            "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
             "cpu": [
                 "arm"
             ],
@@ -80,9 +102,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-            "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+            "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
             "cpu": [
                 "arm64"
             ],
@@ -96,9 +118,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-            "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+            "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
             "cpu": [
                 "x64"
             ],
@@ -112,9 +134,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-            "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+            "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
             "cpu": [
                 "arm64"
             ],
@@ -128,9 +150,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-            "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+            "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
             "cpu": [
                 "x64"
             ],
@@ -144,9 +166,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
             "cpu": [
                 "arm64"
             ],
@@ -160,9 +182,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-            "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+            "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
             "cpu": [
                 "x64"
             ],
@@ -176,9 +198,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-            "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+            "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
             "cpu": [
                 "arm"
             ],
@@ -192,9 +214,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-            "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+            "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
             "cpu": [
                 "arm64"
             ],
@@ -208,9 +230,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-            "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+            "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
             "cpu": [
                 "ia32"
             ],
@@ -224,9 +246,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-            "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+            "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
             "cpu": [
                 "loong64"
             ],
@@ -240,9 +262,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-            "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+            "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -256,9 +278,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-            "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+            "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
             "cpu": [
                 "ppc64"
             ],
@@ -272,9 +294,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-            "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+            "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
             "cpu": [
                 "riscv64"
             ],
@@ -288,9 +310,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-            "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+            "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
             "cpu": [
                 "s390x"
             ],
@@ -304,9 +326,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-            "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+            "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
             "cpu": [
                 "x64"
             ],
@@ -320,9 +342,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
             "cpu": [
                 "arm64"
             ],
@@ -336,9 +358,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+            "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
             "cpu": [
                 "x64"
             ],
@@ -352,9 +374,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
             "cpu": [
                 "arm64"
             ],
@@ -368,9 +390,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+            "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
             "cpu": [
                 "x64"
             ],
@@ -384,9 +406,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-            "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+            "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
             "cpu": [
                 "x64"
             ],
@@ -400,9 +422,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-            "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+            "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
             "cpu": [
                 "arm64"
             ],
@@ -416,9 +438,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-            "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+            "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
             "cpu": [
                 "ia32"
             ],
@@ -432,9 +454,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-            "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+            "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
             "cpu": [
                 "x64"
             ],
@@ -447,6 +469,745 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@eth-optimism/contracts": {
+            "version": "0.5.40",
+            "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.5.40.tgz",
+            "integrity": "sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@eth-optimism/core-utils": "0.12.0",
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/abstract-signer": "^5.7.0"
+            },
+            "peerDependencies": {
+                "ethers": "^5"
+            }
+        },
+        "node_modules/@eth-optimism/core-utils": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz",
+            "integrity": "sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==",
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "^5.7.0",
+                "@ethersproject/abstract-provider": "^5.7.0",
+                "@ethersproject/address": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/constants": "^5.7.0",
+                "@ethersproject/contracts": "^5.7.0",
+                "@ethersproject/hash": "^5.7.0",
+                "@ethersproject/keccak256": "^5.7.0",
+                "@ethersproject/properties": "^5.7.0",
+                "@ethersproject/providers": "^5.7.0",
+                "@ethersproject/rlp": "^5.7.0",
+                "@ethersproject/transactions": "^5.7.0",
+                "@ethersproject/web": "^5.7.0",
+                "bufio": "^1.0.7",
+                "chai": "^4.3.4"
+            }
+        },
+        "node_modules/@ethersproject/abi": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+            "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/abstract-provider": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+            "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/networks": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/web": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/abstract-signer": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+            "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/address": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/base64": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+            "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/basex": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+            "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/bignumber": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+            "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "bn.js": "^5.2.1"
+            }
+        },
+        "node_modules/@ethersproject/bytes": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+            "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/constants": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+            "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/contracts": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
+            "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abi": "^5.8.0",
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/hash": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+            "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/hdnode": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+            "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/basex": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/pbkdf2": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/wordlists": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/json-wallets": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+            "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hdnode": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/pbkdf2": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "aes-js": "3.0.0",
+                "scrypt-js": "3.0.1"
+            }
+        },
+        "node_modules/@ethersproject/keccak256": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+            "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "js-sha3": "0.8.0"
+            }
+        },
+        "node_modules/@ethersproject/logger": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+            "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/@ethersproject/networks": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+            "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/pbkdf2": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+            "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/properties": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+            "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/providers": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+            "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/basex": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/networks": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/web": "^5.8.0",
+                "bech32": "1.1.4",
+                "ws": "8.18.0"
+            }
+        },
+        "node_modules/@ethersproject/random": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+            "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/rlp": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+            "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/sha2": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+            "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "hash.js": "1.1.7"
+            }
+        },
+        "node_modules/@ethersproject/signing-key": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+            "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "bn.js": "^5.2.1",
+                "elliptic": "6.6.1",
+                "hash.js": "1.1.7"
+            }
+        },
+        "node_modules/@ethersproject/solidity": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
+            "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/sha2": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/strings": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+            "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/transactions": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+            "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/rlp": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/units": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
+            "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/constants": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/wallet": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+            "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.8.0",
+                "@ethersproject/abstract-signer": "^5.8.0",
+                "@ethersproject/address": "^5.8.0",
+                "@ethersproject/bignumber": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/hdnode": "^5.8.0",
+                "@ethersproject/json-wallets": "^5.8.0",
+                "@ethersproject/keccak256": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/random": "^5.8.0",
+                "@ethersproject/signing-key": "^5.8.0",
+                "@ethersproject/transactions": "^5.8.0",
+                "@ethersproject/wordlists": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/web": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+            "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/base64": "^5.8.0",
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
+        "node_modules/@ethersproject/wordlists": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+            "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.8.0",
+                "@ethersproject/hash": "^5.8.0",
+                "@ethersproject/logger": "^5.8.0",
+                "@ethersproject/properties": "^5.8.0",
+                "@ethersproject/strings": "^5.8.0"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -454,24 +1215,50 @@
             "license": "MIT"
         },
         "node_modules/@noble/curves": {
-            "version": "1.2.0",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "1.3.2"
+                "@noble/hashes": "1.7.1"
+            },
+            "engines": {
+                "node": "^14.21.3 || >=16"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "1.3.2",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
             "license": "MIT",
             "engines": {
-                "node": ">= 16"
+                "node": "^14.21.3 || >=16"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
+        },
+        "node_modules/@openzeppelin/contracts": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.6.tgz",
+            "integrity": "sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==",
+            "license": "MIT"
+        },
+        "node_modules/@openzeppelin/contracts-upgradeable": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz",
+            "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==",
+            "license": "MIT"
+        },
+        "node_modules/@openzeppelin/contracts-v0.7": {
+            "name": "@openzeppelin/contracts",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
+            "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==",
+            "license": "MIT"
         },
         "node_modules/@parity/revive": {
             "version": "0.0.12",
@@ -483,21 +1270,6 @@
                 "package-json": "^10.0.1",
                 "solc": "^0.8.28"
             }
-        },
-        "node_modules/@parity/revive/node_modules/@types/node": {
-            "version": "22.13.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-            "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~6.20.0"
-            }
-        },
-        "node_modules/@parity/revive/node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-            "license": "MIT"
         },
         "node_modules/@pnpm/config.env-replace": {
             "version": "1.1.0",
@@ -534,10 +1306,79 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.28",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+            "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/@redstone-finance/evm-connector": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@redstone-finance/evm-connector/-/evm-connector-0.6.2.tgz",
+            "integrity": "sha512-bETkpZuc9huSbPPhJ1FEQNFsNlWMez4KCC/geEZLVBus0odRlaQz5hNEiHQS7B0bNxoaOKkOczF6Uq/YeOnoFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@chainlink/contracts": "^0.6.1",
+                "@openzeppelin/contracts": "^4.8.1",
+                "@redstone-finance/protocol": "0.6.2",
+                "@redstone-finance/sdk": "0.6.2",
+                "@redstone-finance/utils": "0.6.2",
+                "axios": "^1.6.2",
+                "ethers": "^5.7.2"
+            }
+        },
+        "node_modules/@redstone-finance/oracles-smartweave-contracts": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@redstone-finance/oracles-smartweave-contracts/-/oracles-smartweave-contracts-0.6.2.tgz",
+            "integrity": "sha512-lXNPgXDKAOl5uShB/nZ9WUDcLWKuq4OZYumPR6HqckEYHGMULIiI2tB2egZl8SVWcpkBZ5RFs47j9bZ22pkm2g==",
+            "license": "MIT"
+        },
+        "node_modules/@redstone-finance/protocol": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@redstone-finance/protocol/-/protocol-0.6.2.tgz",
+            "integrity": "sha512-s5rQNfrAH4A7aObOMZ4G6w/fhxgjoa2KBKqmw9d7pizl2Edzxp1ctrjeKngSPmBRyZcrXPyTiX2Wpwpze2mqxg==",
+            "license": "MIT",
+            "dependencies": {
+                "decimal.js": "^10.4.3",
+                "ethers": "^5.7.2"
+            }
+        },
+        "node_modules/@redstone-finance/sdk": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@redstone-finance/sdk/-/sdk-0.6.2.tgz",
+            "integrity": "sha512-c4mXLYGK7k2zo1t+0biitAZbXdIiex2K9zVQMuo/rrBHjUOdVf/CRKRk7DDG1ZyFZNZV2RWo2FGKAMlbTgaSog==",
+            "license": "MIT",
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/strings": "^5.7.0",
+                "@redstone-finance/oracles-smartweave-contracts": "0.6.2",
+                "@redstone-finance/protocol": "0.6.2",
+                "@redstone-finance/utils": "0.6.2",
+                "@types/lodash": "^4.14.195",
+                "axios": "^1.6.2",
+                "ethers": "^5.7.2",
+                "lodash": "^4.17.21",
+                "zod": "^3.22.4"
+            }
+        },
+        "node_modules/@redstone-finance/utils": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@redstone-finance/utils/-/utils-0.6.2.tgz",
+            "integrity": "sha512-VRrop0uwgh0jc5QHjbDCO7kdG6qbY7iem6tFBYB2JfdrT5N8re42hdjbdiMoWbXJFqbjmAPvsB4JPPGQhVC6IA==",
+            "license": "MIT",
+            "dependencies": {
+                "axios": "^1.6.2",
+                "consola": "^2.15.3",
+                "decimal.js": "^10.4.3",
+                "ethers": "^5.7.2",
+                "zod": "^3.22.4"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-            "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
+            "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
             "cpu": [
                 "arm"
             ],
@@ -548,9 +1389,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-            "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
+            "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
             "cpu": [
                 "arm64"
             ],
@@ -561,9 +1402,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-            "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
+            "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
             "cpu": [
                 "arm64"
             ],
@@ -574,9 +1415,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-            "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+            "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
             "cpu": [
                 "x64"
             ],
@@ -587,9 +1428,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-            "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
+            "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
             "cpu": [
                 "arm64"
             ],
@@ -600,9 +1441,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-            "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
+            "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
             "cpu": [
                 "x64"
             ],
@@ -613,9 +1454,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-            "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
+            "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
             "cpu": [
                 "arm"
             ],
@@ -626,9 +1467,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-            "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
+            "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
             "cpu": [
                 "arm"
             ],
@@ -639,9 +1480,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-            "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+            "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
             "cpu": [
                 "arm64"
             ],
@@ -652,9 +1493,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-            "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+            "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
             "cpu": [
                 "arm64"
             ],
@@ -665,9 +1506,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-            "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
+            "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
             "cpu": [
                 "loong64"
             ],
@@ -678,9 +1519,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-            "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
+            "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
             "cpu": [
                 "ppc64"
             ],
@@ -691,9 +1532,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-            "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
+            "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
             "cpu": [
                 "riscv64"
             ],
@@ -704,9 +1545,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-            "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
+            "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
             "cpu": [
                 "s390x"
             ],
@@ -717,9 +1558,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-            "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+            "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
             "cpu": [
                 "x64"
             ],
@@ -730,9 +1571,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-            "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+            "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
             "cpu": [
                 "x64"
             ],
@@ -743,9 +1584,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-            "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+            "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
             "cpu": [
                 "arm64"
             ],
@@ -756,9 +1597,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-            "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
+            "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
             "cpu": [
                 "ia32"
             ],
@@ -769,9 +1610,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-            "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+            "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
             "cpu": [
                 "x64"
             ],
@@ -804,33 +1645,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/@scure/bip32/node_modules/@noble/curves": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "1.7.1"
-            },
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/@scure/bip39": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
@@ -839,18 +1653,6 @@
             "dependencies": {
                 "@noble/hashes": "~1.7.1",
                 "@scure/base": "~1.2.4"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
@@ -898,13 +1700,19 @@
             "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
             "license": "MIT"
         },
+        "node_modules/@types/lodash": {
+            "version": "4.17.16",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+            "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+            "license": "MIT"
+        },
         "node_modules/@types/node": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+            "version": "22.13.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+            "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.20.0"
             }
         },
         "node_modules/@vitest/expect": {
@@ -920,6 +1728,64 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/expect/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@vitest/expect/node_modules/chai": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@vitest/expect/node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            }
+        },
+        "node_modules/@vitest/expect/node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@vitest/expect/node_modules/loupe": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+            "license": "MIT"
+        },
+        "node_modules/@vitest/expect/node_modules/pathval": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
             }
         },
         "node_modules/@vitest/mocker": {
@@ -999,6 +1865,28 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/ui": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.6.tgz",
+            "integrity": "sha512-N4M2IUG2Q5LCeX4OWs48pQF4P3qsFejmDTc6QWGRFTLPrEe5EvM5HN0WSUnGAmuzQpSWv7ItfSsIJIWaEM2wpQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.0.6",
+                "fflate": "^0.8.2",
+                "flatted": "^3.3.2",
+                "pathe": "^2.0.3",
+                "sirv": "^3.0.1",
+                "tinyglobby": "^0.2.11",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "3.0.6"
+            }
+        },
         "node_modules/@vitest/utils": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.6.tgz",
@@ -1012,6 +1900,12 @@
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
+        },
+        "node_modules/@vitest/utils/node_modules/loupe": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+            "license": "MIT"
         },
         "node_modules/abitype": {
             "version": "1.0.8",
@@ -1035,7 +1929,9 @@
             }
         },
         "node_modules/aes-js": {
-            "version": "4.0.0-beta.5",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+            "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
             "license": "MIT"
         },
         "node_modules/ajv": {
@@ -1094,12 +1990,12 @@
             "license": "Python-2.0"
         },
         "node_modules/assertion-error": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": "*"
             }
         },
         "node_modules/ast-parents": {
@@ -1117,10 +2013,39 @@
                 "node": ">=8"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+            "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
+        },
+        "node_modules/bech32": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+            "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+            "license": "MIT"
+        },
+        "node_modules/bn.js": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
@@ -1130,6 +2055,21 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "license": "MIT"
+        },
+        "node_modules/bufio": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.3.tgz",
+            "integrity": "sha512-5Tt66bRzYUSlVZatc0E92uDenreJ+DpTBmSAUwL4VSxJn3e6cUyYwx+PoqML0GRZatgA/VX8ybhxItF8InZgqA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/cac": {
@@ -1168,6 +2108,19 @@
                 "node": ">=14.16"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1178,19 +2131,21 @@
             }
         },
         "node_modules/chai": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
             "license": "MIT",
             "dependencies": {
-                "assertion-error": "^2.0.1",
-                "check-error": "^2.1.1",
-                "deep-eql": "^5.0.1",
-                "loupe": "^3.1.0",
-                "pathval": "^2.0.0"
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
+                "pathval": "^1.1.1",
+                "type-detect": "^4.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=4"
             }
         },
         "node_modules/chalk": {
@@ -1210,12 +2165,15 @@
             }
         },
         "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "license": "MIT",
+            "dependencies": {
+                "get-func-name": "^2.0.2"
+            },
             "engines": {
-                "node": ">= 16"
+                "node": "*"
             }
         },
         "node_modules/color-convert": {
@@ -1235,6 +2193,18 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/command-exists": {
             "version": "1.2.9",
@@ -1260,6 +2230,12 @@
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
             }
+        },
+        "node_modules/consola": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+            "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
+            "license": "MIT"
         },
         "node_modules/cosmiconfig": {
             "version": "8.3.6",
@@ -1304,6 +2280,12 @@
                 }
             }
         },
+        "node_modules/decimal.js": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+            "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+            "license": "MIT"
+        },
         "node_modules/decompress-response": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -1332,10 +2314,13 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
             "license": "MIT",
+            "dependencies": {
+                "type-detect": "^4.0.0"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -1358,6 +2343,50 @@
                 "node": ">=10"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/elliptic": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/elliptic/node_modules/bn.js": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+            "license": "MIT"
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1373,16 +2402,61 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-module-lexer": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
             "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
             "license": "MIT"
         },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/esbuild": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-            "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+            "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -1392,31 +2466,31 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.24.2",
-                "@esbuild/android-arm": "0.24.2",
-                "@esbuild/android-arm64": "0.24.2",
-                "@esbuild/android-x64": "0.24.2",
-                "@esbuild/darwin-arm64": "0.24.2",
-                "@esbuild/darwin-x64": "0.24.2",
-                "@esbuild/freebsd-arm64": "0.24.2",
-                "@esbuild/freebsd-x64": "0.24.2",
-                "@esbuild/linux-arm": "0.24.2",
-                "@esbuild/linux-arm64": "0.24.2",
-                "@esbuild/linux-ia32": "0.24.2",
-                "@esbuild/linux-loong64": "0.24.2",
-                "@esbuild/linux-mips64el": "0.24.2",
-                "@esbuild/linux-ppc64": "0.24.2",
-                "@esbuild/linux-riscv64": "0.24.2",
-                "@esbuild/linux-s390x": "0.24.2",
-                "@esbuild/linux-x64": "0.24.2",
-                "@esbuild/netbsd-arm64": "0.24.2",
-                "@esbuild/netbsd-x64": "0.24.2",
-                "@esbuild/openbsd-arm64": "0.24.2",
-                "@esbuild/openbsd-x64": "0.24.2",
-                "@esbuild/sunos-x64": "0.24.2",
-                "@esbuild/win32-arm64": "0.24.2",
-                "@esbuild/win32-ia32": "0.24.2",
-                "@esbuild/win32-x64": "0.24.2"
+                "@esbuild/aix-ppc64": "0.25.0",
+                "@esbuild/android-arm": "0.25.0",
+                "@esbuild/android-arm64": "0.25.0",
+                "@esbuild/android-x64": "0.25.0",
+                "@esbuild/darwin-arm64": "0.25.0",
+                "@esbuild/darwin-x64": "0.25.0",
+                "@esbuild/freebsd-arm64": "0.25.0",
+                "@esbuild/freebsd-x64": "0.25.0",
+                "@esbuild/linux-arm": "0.25.0",
+                "@esbuild/linux-arm64": "0.25.0",
+                "@esbuild/linux-ia32": "0.25.0",
+                "@esbuild/linux-loong64": "0.25.0",
+                "@esbuild/linux-mips64el": "0.25.0",
+                "@esbuild/linux-ppc64": "0.25.0",
+                "@esbuild/linux-riscv64": "0.25.0",
+                "@esbuild/linux-s390x": "0.25.0",
+                "@esbuild/linux-x64": "0.25.0",
+                "@esbuild/netbsd-arm64": "0.25.0",
+                "@esbuild/netbsd-x64": "0.25.0",
+                "@esbuild/openbsd-arm64": "0.25.0",
+                "@esbuild/openbsd-x64": "0.25.0",
+                "@esbuild/sunos-x64": "0.25.0",
+                "@esbuild/win32-arm64": "0.25.0",
+                "@esbuild/win32-ia32": "0.25.0",
+                "@esbuild/win32-x64": "0.25.0"
             }
         },
         "node_modules/estree-walker": {
@@ -1429,13 +2503,13 @@
             }
         },
         "node_modules/ethers": {
-            "version": "6.13.5",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
-            "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+            "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://github.com/sponsors/ethers-io/"
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
                 },
                 {
                     "type": "individual",
@@ -1444,16 +2518,36 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@adraffy/ens-normalize": "1.10.1",
-                "@noble/curves": "1.2.0",
-                "@noble/hashes": "1.3.2",
-                "@types/node": "22.7.5",
-                "aes-js": "4.0.0-beta.5",
-                "tslib": "2.7.0",
-                "ws": "8.17.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "@ethersproject/abi": "5.8.0",
+                "@ethersproject/abstract-provider": "5.8.0",
+                "@ethersproject/abstract-signer": "5.8.0",
+                "@ethersproject/address": "5.8.0",
+                "@ethersproject/base64": "5.8.0",
+                "@ethersproject/basex": "5.8.0",
+                "@ethersproject/bignumber": "5.8.0",
+                "@ethersproject/bytes": "5.8.0",
+                "@ethersproject/constants": "5.8.0",
+                "@ethersproject/contracts": "5.8.0",
+                "@ethersproject/hash": "5.8.0",
+                "@ethersproject/hdnode": "5.8.0",
+                "@ethersproject/json-wallets": "5.8.0",
+                "@ethersproject/keccak256": "5.8.0",
+                "@ethersproject/logger": "5.8.0",
+                "@ethersproject/networks": "5.8.0",
+                "@ethersproject/pbkdf2": "5.8.0",
+                "@ethersproject/properties": "5.8.0",
+                "@ethersproject/providers": "5.8.0",
+                "@ethersproject/random": "5.8.0",
+                "@ethersproject/rlp": "5.8.0",
+                "@ethersproject/sha2": "5.8.0",
+                "@ethersproject/signing-key": "5.8.0",
+                "@ethersproject/solidity": "5.8.0",
+                "@ethersproject/strings": "5.8.0",
+                "@ethersproject/transactions": "5.8.0",
+                "@ethersproject/units": "5.8.0",
+                "@ethersproject/wallet": "5.8.0",
+                "@ethersproject/web": "5.8.0",
+                "@ethersproject/wordlists": "5.8.0"
             }
         },
         "node_modules/eventemitter3": {
@@ -1463,9 +2557,9 @@
             "license": "MIT"
         },
         "node_modules/expect-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
-            "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
+            "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
@@ -1505,6 +2599,35 @@
             ],
             "license": "BSD-3-Clause"
         },
+        "node_modules/fdir": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "devOptional": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/flatted": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "devOptional": true,
+            "license": "ISC"
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -1523,6 +2646,21 @@
                 "debug": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/form-data-encoder": {
@@ -1552,6 +2690,61 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-func-name": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -1584,6 +2777,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/got": {
@@ -1624,6 +2829,66 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "license": "MIT",
+            "dependencies": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "node_modules/http-cache-semantics": {
@@ -1819,18 +3084,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/latest-version/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -1850,10 +3103,13 @@
             "license": "MIT"
         },
         "node_modules/loupe": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-            "license": "MIT"
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+            "license": "MIT",
+            "dependencies": {
+                "get-func-name": "^2.0.1"
+            }
         },
         "node_modules/lowercase-keys": {
             "version": "3.0.0",
@@ -1876,12 +3132,42 @@
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/memorystream": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
             "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-response": {
@@ -1895,6 +3181,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "license": "ISC"
+        },
+        "node_modules/minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "5.1.6",
@@ -1915,6 +3213,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/ms": {
@@ -2000,33 +3308,6 @@
                 }
             }
         },
-        "node_modules/ox/node_modules/@noble/curves": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "1.7.1"
-            },
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/ox/node_modules/@noble/hashes": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/p-cancelable": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -2052,18 +3333,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/package-json/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/parent-module": {
@@ -2112,12 +3381,12 @@
             "license": "MIT"
         },
         "node_modules/pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
             "license": "MIT",
             "engines": {
-                "node": ">= 14.16"
+                "node": "*"
             }
         },
         "node_modules/picocolors": {
@@ -2125,6 +3394,19 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
@@ -2136,9 +3418,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-            "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2164,9 +3446,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-            "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -2183,6 +3465,12 @@
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "license": "ISC"
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -2287,9 +3575,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.34.8",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-            "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
+            "version": "4.34.9",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
+            "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
@@ -2302,35 +3590,44 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.34.8",
-                "@rollup/rollup-android-arm64": "4.34.8",
-                "@rollup/rollup-darwin-arm64": "4.34.8",
-                "@rollup/rollup-darwin-x64": "4.34.8",
-                "@rollup/rollup-freebsd-arm64": "4.34.8",
-                "@rollup/rollup-freebsd-x64": "4.34.8",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-                "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-                "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-                "@rollup/rollup-linux-arm64-musl": "4.34.8",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-                "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-                "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-gnu": "4.34.8",
-                "@rollup/rollup-linux-x64-musl": "4.34.8",
-                "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-                "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-                "@rollup/rollup-win32-x64-msvc": "4.34.8",
+                "@rollup/rollup-android-arm-eabi": "4.34.9",
+                "@rollup/rollup-android-arm64": "4.34.9",
+                "@rollup/rollup-darwin-arm64": "4.34.9",
+                "@rollup/rollup-darwin-x64": "4.34.9",
+                "@rollup/rollup-freebsd-arm64": "4.34.9",
+                "@rollup/rollup-freebsd-x64": "4.34.9",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
+                "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
+                "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+                "@rollup/rollup-linux-arm64-musl": "4.34.9",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
+                "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
+                "@rollup/rollup-linux-s390x-gnu": "4.34.9",
+                "@rollup/rollup-linux-x64-gnu": "4.34.9",
+                "@rollup/rollup-linux-x64-musl": "4.34.9",
+                "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+                "@rollup/rollup-win32-ia32-msvc": "4.34.9",
+                "@rollup/rollup-win32-x64-msvc": "4.34.9",
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/scrypt-js": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+            "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+            "license": "MIT"
+        },
         "node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "license": "ISC",
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/siginfo": {
@@ -2338,6 +3635,21 @@
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "license": "ISC"
+        },
+        "node_modules/sirv": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+            "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
@@ -2375,6 +3687,15 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/solc/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
             }
         },
         "node_modules/solhint": {
@@ -2432,18 +3753,6 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/solhint/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/source-map-js": {
@@ -2570,6 +3879,23 @@
             "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
             "license": "MIT"
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.4.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
         "node_modules/tinypool": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -2609,16 +3935,29 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-            "license": "0BSD"
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2630,9 +3969,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "license": "MIT"
         },
         "node_modules/uri-js": {
@@ -2645,9 +3984,9 @@
             }
         },
         "node_modules/viem": {
-            "version": "2.23.2",
-            "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
-            "integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+            "version": "2.23.5",
+            "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.5.tgz",
+            "integrity": "sha512-cUfBHdFQHmBlPW0loFXda0uZcoU+uJw3NRYQRwYgkrpH6PgovH8iuVqDn6t1jZk82zny4wQL54c9dCX2W9kLMg==",
             "funding": [
                 {
                     "type": "github",
@@ -2674,62 +4013,14 @@
                 }
             }
         },
-        "node_modules/viem/node_modules/@noble/curves": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "1.7.1"
-            },
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/viem/node_modules/@noble/hashes": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.21.3 || >=16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/viem/node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/vite": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-            "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
+            "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.24.2",
-                "postcss": "^8.5.1",
+                "esbuild": "^0.25.0",
+                "postcss": "^8.5.3",
                 "rollup": "^4.30.1"
             },
             "bin": {
@@ -2884,6 +4175,64 @@
                 }
             }
         },
+        "node_modules/vitest/node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/chai": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            }
+        },
+        "node_modules/vitest/node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/vitest/node_modules/loupe": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+            "license": "MIT"
+        },
+        "node_modules/vitest/node_modules/pathval": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2907,7 +4256,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.17.1",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -2923,6 +4274,15 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.24.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+            "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/eth-rpc/package.json
+++ b/eth-rpc/package.json
@@ -11,7 +11,7 @@
         "solhint": "solhint \"contracts/**/*.sol\""
     },
     "dependencies": {
-        "@parity/revive": "^0.0.12",
+        "@parity/revive": "^0.0.14",
         "@redstone-finance/evm-connector": "^0.6.2",
         "ethers": "^5.6.9",
         "prettier": "^3.5.1",

--- a/eth-rpc/package.json
+++ b/eth-rpc/package.json
@@ -12,7 +12,8 @@
     },
     "dependencies": {
         "@parity/revive": "^0.0.12",
-        "ethers": "^6.13.5",
+        "@redstone-finance/evm-connector": "^0.6.2",
+        "ethers": "^5.6.9",
         "prettier": "^3.5.1",
         "solc": "^0.8.28",
         "solhint": "^5.0.5",
@@ -20,6 +21,7 @@
         "vitest": "^3.0.6"
     },
     "devDependencies": {
+        "@vitest/ui": "^3.0.6",
         "typescript": "^5.7.2"
     }
 }

--- a/eth-rpc/package.json
+++ b/eth-rpc/package.json
@@ -21,7 +21,6 @@
         "vitest": "^3.0.6"
     },
     "devDependencies": {
-        "@vitest/ui": "^3.0.6",
         "typescript": "^5.7.2"
     }
 }

--- a/eth-rpc/src/build-contracts.ts
+++ b/eth-rpc/src/build-contracts.ts
@@ -70,8 +70,14 @@ for (const file of input) {
     }
 
     if (!solcOnly) {
-        console.log('Compiling with revive...')
-        const reviveOut = await compile(input)
+        if (process.env.REVIVE_BIN === undefined) {
+            console.log('Compiling with revive...')
+        } else {
+            console.log(
+                `Compiling with revive (using ${process.env.REVIVE_BIN})...`
+            )
+        }
+        const reviveOut = await compile(input, { bin: process.env.REVIVE_BIN })
 
         for (const contracts of Object.values(reviveOut.contracts)) {
             for (const [name, contract] of Object.entries(contracts)) {

--- a/eth-rpc/src/redstone.test.ts
+++ b/eth-rpc/src/redstone.test.ts
@@ -24,22 +24,32 @@ for (const env of envs) {
         }
     )
 
-    describe(`${env.serverWallet.chain.name}`, () => {
-        test('getTokensPrices works', async () => {
-            const contract = new Contract(
-                contractAddress,
-                ExampleRedstoneShowroomAbi as any,
-                provider
-            )
-            const wrappedContract = WrapperBuilder.wrap(
-                contract
-            ).usingDataService({
-                dataServiceId: 'redstone-rapid-demo',
-                uniqueSignersCount: 1,
-                dataPackagesIds: ['BTC', 'ETH', 'BNB', 'AR', 'AVAX', 'CELO'],
+    describe.runIf(process.env.UNSTABLE)(
+        `${env.serverWallet.chain.name}`,
+        () => {
+            test('getTokensPrices works', async () => {
+                const contract = new Contract(
+                    contractAddress,
+                    ExampleRedstoneShowroomAbi as any,
+                    provider
+                )
+                const wrappedContract = WrapperBuilder.wrap(
+                    contract
+                ).usingDataService({
+                    dataServiceId: 'redstone-rapid-demo',
+                    uniqueSignersCount: 1,
+                    dataPackagesIds: [
+                        'BTC',
+                        'ETH',
+                        'BNB',
+                        'AR',
+                        'AVAX',
+                        'CELO',
+                    ],
+                })
+                const tokenPrices = await wrappedContract.getPrices()
+                expect(tokenPrices).toHaveLength(6)
             })
-            const tokenPrices = await wrappedContract.getPrices()
-            expect(tokenPrices).toHaveLength(6)
-        })
-    })
+        }
+    )
 }

--- a/eth-rpc/src/redstone.test.ts
+++ b/eth-rpc/src/redstone.test.ts
@@ -1,0 +1,45 @@
+import { ExampleRedstoneShowroomAbi } from '../abi/ExampleRedstoneShowroom.ts'
+import { createEnv, getByteCode } from './util.ts'
+import { Contract, providers } from 'ethers'
+import { WrapperBuilder } from '@redstone-finance/evm-connector'
+import { describe, expect, inject, test } from 'vitest'
+
+const envs = await Promise.all(inject('envs').map(createEnv))
+
+for (const env of envs) {
+    const hash = await env.serverWallet.deployContract({
+        abi: ExampleRedstoneShowroomAbi,
+        bytecode: getByteCode('ExampleRedstoneShowroom', env.evm),
+    })
+    const deployReceipt = await env.serverWallet.waitForTransactionReceipt({
+        hash,
+    })
+    const contractAddress = deployReceipt.contractAddress!
+
+    const provider = new providers.JsonRpcProvider(
+        env.chain.rpcUrls.default.http[0],
+        {
+            name: env.chain.name,
+            chainId: env.chain.id,
+        }
+    )
+
+    describe(`${env.serverWallet.chain.name}`, () => {
+        test('getTokensPrices works', async () => {
+            const contract = new Contract(
+                contractAddress,
+                ExampleRedstoneShowroomAbi as any,
+                provider
+            )
+            const wrappedContract = WrapperBuilder.wrap(
+                contract
+            ).usingDataService({
+                dataServiceId: 'redstone-rapid-demo',
+                uniqueSignersCount: 1,
+                dataPackagesIds: ['BTC', 'ETH', 'BNB', 'AR', 'AVAX', 'CELO'],
+            })
+            const tokenPrices = await wrappedContract.getPrices()
+            expect(tokenPrices).toHaveLength(6)
+        })
+    })
+}

--- a/eth-rpc/src/redstone.test.ts
+++ b/eth-rpc/src/redstone.test.ts
@@ -24,32 +24,22 @@ for (const env of envs) {
         }
     )
 
-    describe.runIf(process.env.UNSTABLE)(
-        `${env.serverWallet.chain.name}`,
-        () => {
-            test('getTokensPrices works', async () => {
-                const contract = new Contract(
-                    contractAddress,
-                    ExampleRedstoneShowroomAbi as any,
-                    provider
-                )
-                const wrappedContract = WrapperBuilder.wrap(
-                    contract
-                ).usingDataService({
-                    dataServiceId: 'redstone-rapid-demo',
-                    uniqueSignersCount: 1,
-                    dataPackagesIds: [
-                        'BTC',
-                        'ETH',
-                        'BNB',
-                        'AR',
-                        'AVAX',
-                        'CELO',
-                    ],
-                })
-                const tokenPrices = await wrappedContract.getPrices()
-                expect(tokenPrices).toHaveLength(6)
+    describe(`${env.serverWallet.chain.name}`, () => {
+        test('getTokensPrices works', async () => {
+            const contract = new Contract(
+                contractAddress,
+                ExampleRedstoneShowroomAbi as any,
+                provider
+            )
+            const wrappedContract = WrapperBuilder.wrap(
+                contract
+            ).usingDataService({
+                dataServiceId: 'redstone-rapid-demo',
+                uniqueSignersCount: 1,
+                dataPackagesIds: ['BTC', 'ETH', 'BNB', 'AR', 'AVAX', 'CELO'],
             })
-        }
-    )
+            const tokenPrices = await wrappedContract.getPrices()
+            expect(tokenPrices).toHaveLength(6)
+        })
+    })
 }

--- a/eth-rpc/src/test-setup.ts
+++ b/eth-rpc/src/test-setup.ts
@@ -1,0 +1,76 @@
+import { killProcessOnPort, waitForHealth } from './util.ts'
+import assert from 'node:assert'
+import { ChildProcess, spawn } from 'node:child_process'
+import { TestProject } from 'vitest/node.js'
+
+declare module 'vitest' {
+    export interface ProvidedContext {
+        envs: Array<'geth' | 'eth-rpc'>
+    }
+}
+
+export default async function setup(project: TestProject) {
+    const procs: ChildProcess[] = []
+    let useGeth = !!process.env.USE_GETH
+    let useEthRpc = !!process.env.USE_ETH_RPC
+
+    if (process.env.START_GETH) {
+        useGeth = true
+        const geth = process.env.GETH_BIN ?? 'geth'
+        const gethArgs = [
+            '--http',
+            '--http.api',
+            'web3,eth,debug,personal,net',
+            '--http.port',
+            '8546',
+            '--dev',
+            '--verbosity',
+            '0',
+        ]
+
+        killProcessOnPort(8546)
+        console.log('🚀 Start geth...')
+        procs.push(spawn(geth, gethArgs))
+        await waitForHealth('http://localhost:8546').catch()
+    }
+
+    if (process.env.START_SUBSTRATE_NODE) {
+        const substrateNodeArgs = [
+            '--dev',
+            '-l=error,evm=debug,sc_rpc_server=info,runtime::revive=debug',
+        ]
+
+        killProcessOnPort(9944)
+        assert(process.env.NODE_PATH, 'NODE_PATH should be set')
+        console.log('🚀 Start substrate-node ...')
+        procs.push(spawn(process.env.NODE_PATH, substrateNodeArgs))
+    }
+
+    if (process.env.START_ETH_RPC) {
+        useEthRpc = true
+
+        // Run eth-rpc on 8545
+        const ethRpcArgs = [
+            '--dev',
+            '--node-rpc-url=ws://localhost:9944',
+            '-l=rpc-metrics=debug,eth-rpc=debug',
+        ]
+
+        killProcessOnPort(8545)
+        assert(process.env.ADAPTER_PATH, 'ADAPTER_PATH should be set')
+        console.log('🚀 Start eth-rpc ...')
+        procs.push(spawn(process.env.ADAPTER_PATH, ethRpcArgs))
+        await waitForHealth('http://localhost:8545').catch()
+    }
+
+    const envs = [
+        ...(useGeth ? ['geth' as const] : []),
+        ...(useEthRpc ? ['eth-rpc' as const] : []),
+    ]
+
+    project.provide('envs', envs)
+
+    return () => {
+        procs.forEach((proc) => proc.kill())
+    }
+}

--- a/eth-rpc/src/util.ts
+++ b/eth-rpc/src/util.ts
@@ -29,13 +29,7 @@ export type JsonRpcError = {
 export function killProcessOnPort(port: number) {
     // Check which process is using the specified port
     const result = spawnSync('lsof', ['-ti', `:${port}`])
-    const pids = result.stdout
-        .toString()
-        .trim()
-        .split('\n')
-        .filter(Boolean)
-        .map(Number)
-        .filter((p) => p !== process.ppid && p !== process.pid)
+    const pids = result.stdout.toString().trim().split('\n').filter(Boolean)
 
     if (pids.length) {
         console.log(` Port ${port} is in use. Killing process...`)

--- a/eth-rpc/src/util.ts
+++ b/eth-rpc/src/util.ts
@@ -1,7 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { resolve } from 'node:path'
 import { readFileSync } from 'node:fs'
-import { Buffer } from 'node:buffer'
 import {
     CallParameters,
     createClient,
@@ -31,15 +29,20 @@ export type JsonRpcError = {
 export function killProcessOnPort(port: number) {
     // Check which process is using the specified port
     const result = spawnSync('lsof', ['-ti', `:${port}`])
-    const output = result.stdout.toString().trim()
+    const pids = result.stdout
+        .toString()
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(Number)
+        .filter((p) => p !== process.ppid && p !== process.pid)
 
-    if (output) {
-        console.log(`Port ${port} is in use. Killing process...`)
-        const pids = output.split('\n')
+    if (pids.length) {
+        console.log(` Port ${port} is in use. Killing process...`)
 
         // Kill each process using the port
         for (const pid of pids) {
-            spawnSync('kill', ['-9', pid])
+            process.kill(Number(pid), 'SIGKILL')
             console.log(`Killed process with PID: ${pid}`)
         }
     }
@@ -47,8 +50,8 @@ export function killProcessOnPort(port: number) {
 
 export let jsonRpcErrors: JsonRpcError[] = []
 export async function createEnv(name: 'geth' | 'eth-rpc') {
-    const gethPort = process.env.GETH_PORT || '8546'
-    const ethRpcPort = process.env.ETH_RPC_PORT || '8545'
+    const gethPort = process.env.GETH_PORT ?? '8546'
+    const ethRpcPort = process.env.ETH_RPC_PORT ?? '8545'
     const url = `http://localhost:${name == 'geth' ? gethPort : ethRpcPort}`
 
     let id = await (async () => {
@@ -164,6 +167,7 @@ export async function createEnv(name: 'geth' | 'eth-rpc') {
     }))
 
     return {
+        chain,
         debugClient,
         emptyWallet,
         serverWallet,

--- a/eth-rpc/vitest.config.ts
+++ b/eth-rpc/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-    test: {
-        globals: true,
-    },
-})

--- a/eth-rpc/vitest.workspace.ts
+++ b/eth-rpc/vitest.workspace.ts
@@ -2,9 +2,10 @@ import { defineWorkspace } from 'vitest/config'
 
 export default defineWorkspace([
     {
-        extends: './vitest.config.ts',
         test: {
+            globals: true,
             name: 'unit',
+            globalSetup: './src/test-setup.ts',
             include: ['./src/*.test.ts'],
         },
     },


### PR DESCRIPTION
- Add Redstone tests (only enable when UNSTABLE env is set as it only works with geth for now)
- Fix up some lint rules and ignored  compilation errors when compiling with solc 
- move global server inits to eth-rpc/src/test-setup.ts


Repro instructions:

```sh
# Compile kitchensink & eth-rpc
# assuming polkadot-sdk is checked out under ~/polkadot-sdk
cd ~/polkadot-sdk
cargo build --bin substrate-node
cargo build -p pallet-revive-eth-rpc --bin eth-rpc 

# export NODE_PATH and ADAPTER_PATH (used by evm-test-suite)
export ADAPTER_PATH=$(realpath ~/polkadot-sdk/target/debug/eth-rpc)
export NODE_PATH=$(realpath ~/polkadot-sdk/target/debug/substrate-node)

# Clone evm-test-suite and checkout PR 
git clone https://github.com/paritytech/evm-test-suite
gh pr checkout 82

# install deps & compile contracts
cd evm-test-suite/eth-rpc
npm install
npm run build
# or if you want to build with resolc bin from path
# REVIVE_BIN=resolc npm run build

# start the failing test
UNSTABLE=true START_SUBSTRATE_NODE=true START_ETH_RPC=true npm run test redstone
```
